### PR TITLE
fix Items

### DIFF
--- a/Template_App_Nginx.xml
+++ b/Template_App_Nginx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2018-02-24T15:22:40Z</date>
+    <date>2018-04-01T19:27:33Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -63,16 +63,11 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>\s\d+\s\d+\s\d+
-\0</params>
+                            <params>(?:server accepts handled requests\r?\n)\s?(\d+)\s(\d+)\s(\d+)
+\1</params>
                         </step>
                         <step>
-                            <type>5</type>
-                            <params>\d+
-\0</params>
-                        </step>
-                        <step>
-                            <type>10</type>
+                            <type>9</type>
                             <params/>
                         </step>
                     </preprocessing>
@@ -111,23 +106,14 @@
                     <port/>
                     <description/>
                     <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>Nginx</name>
-                        </application>
-                    </applications>
+                    <applications/>
                     <valuemap/>
                     <logtimefmt/>
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>Active(.*)
-\0</params>
-                        </step>
-                        <step>
-                            <type>5</type>
-                            <params>\d+
-\0</params>
+                            <params>Active connections:\s?(\d+) 
+\1</params>
                         </step>
                     </preprocessing>
                     <jmx_endpoint/>
@@ -175,21 +161,11 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>\s\d+\s\d+\s\d+
-\0</params>
+                            <params>(?:server accepts handled requests\r?\n)\s?(\d+)\s(\d+)\s(\d+)
+\2</params>
                         </step>
                         <step>
-                            <type>5</type>
-                            <params>\s\d+\s\d+\s
-\0</params>
-                        </step>
-                        <step>
-                            <type>5</type>
-                            <params>\s\d+\s(.*)
-\1</params>
-                        </step>
-                        <step>
-                            <type>10</type>
+                            <type>9</type>
                             <params/>
                         </step>
                     </preprocessing>
@@ -238,13 +214,8 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>Reading:(.*)
-\0</params>
-                        </step>
-                        <step>
-                            <type>5</type>
-                            <params>\d+
-\0</params>
+                            <params>Reading:\s?(\d+)
+\1</params>
                         </step>
                     </preprocessing>
                     <jmx_endpoint/>
@@ -292,16 +263,11 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>\s\d+\s\d+\s\d+
-\0</params>
+                            <params>(?:server accepts handled requests\r?\n)\s?(\d+)\s(\d+)\s(\d+)
+\3</params>
                         </step>
                         <step>
-                            <type>5</type>
-                            <params>\s\d+\s\d+\s(.*)
-\1</params>
-                        </step>
-                        <step>
-                            <type>10</type>
+                            <type>9</type>
                             <params/>
                         </step>
                     </preprocessing>
@@ -350,13 +316,8 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>Waiting:(.*)
-\0</params>
-                        </step>
-                        <step>
-                            <type>5</type>
-                            <params>\d+
-\0</params>
+                            <params>Waiting:\s?(\d+)
+\1</params>
                         </step>
                     </preprocessing>
                     <jmx_endpoint/>
@@ -404,13 +365,8 @@
                     <preprocessing>
                         <step>
                             <type>5</type>
-                            <params>Writing:(.*)
-\0</params>
-                        </step>
-                        <step>
-                            <type>5</type>
-                            <params>\d+
-\0</params>
+                            <params>Writing:\s?(\d+)
+\1</params>
                         </step>
                     </preprocessing>
                     <jmx_endpoint/>
@@ -757,7 +713,7 @@
                     <drawtype>5</drawtype>
                     <color>1A7C11</color>
                     <yaxisside>1</yaxisside>
-                    <calc_fnc>2</calc_fnc>
+                    <calc_fnc>7</calc_fnc>
                     <type>0</type>
                     <item>
                         <host>Template App Nginx by Alex Gluck</host>


### PR DESCRIPTION
1. Better regexps for catching the needed data in one step with group capture
2. Per-seconds items should use "Simple change" (**value-prev_value**) as nginx_status shows just growing up values so we need to catch the difference between current and last value (that will be connections/requests made in one sec)
https://www.zabbix.com/documentation/3.4/manual/config/items/item